### PR TITLE
GEN-39: Define routes for flight search functionality

### DIFF
--- a/app/exceptions.py
+++ b/app/exceptions.py
@@ -1,0 +1,2 @@
+class FlightSearchError(Exception):
+    pass

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,7 @@
+from fastapi import FastAPI
+
+app = FastAPI()
+
+@app.get('/flights')
+def search_flights():
+    pass

--- a/app/main.py
+++ b/app/main.py
@@ -1,7 +1,31 @@
-from fastapi import FastAPI
+from typing import List
+from fastapi import FastAPI, HTTPException, Query
+from .models import FlightSearch, FlightResult
+from .services import search_flights_in_tequila, fetch_flight_details
 
 app = FastAPI()
 
-@app.get('/flights')
-def search_flights():
-    pass
+@app.get('/flights', response_model=List[FlightResult])
+def search_flights(
+    origin: str = Query(...),
+    destination: str = Query(...),
+    departure_date: str = Query(...),
+    return_date: str = Query(...)
+):
+    search = FlightSearch(
+        origin=origin,
+        destination=destination,
+        departure_date=departure_date,
+        return_date=return_date
+    )
+    try:
+        return search_flights_in_tequila(search)
+    except FlightSearchError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+@app.get('/flights/{flight_id}', response_model=FlightResult)
+def get_flight(flight_id: str):
+    try:
+        return fetch_flight_details(flight_id)
+    except FlightSearchError as e:
+        raise HTTPException(status_code=400, detail=str(e))

--- a/app/models.py
+++ b/app/models.py
@@ -1,7 +1,15 @@
 from pydantic import BaseModel
 
 class FlightSearch(BaseModel):
-    pass
+    origin: str
+    destination: str
+    departure_date: str
+    return_date: str
 
 class FlightResult(BaseModel):
-    pass
+    id: str
+    origin: str
+    destination: str
+    departure_date: str
+    return_date: str
+    price: float

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,7 @@
+from pydantic import BaseModel
+
+class FlightSearch(BaseModel):
+    pass
+
+class FlightResult(BaseModel):
+    pass

--- a/app/services.py
+++ b/app/services.py
@@ -1,4 +1,14 @@
 import requests
+from typing import List
+from .models import FlightSearch, FlightResult
+from .exceptions import FlightSearchError
 
-def search_flights_in_tequila():
-    pass
+def search_flights_in_tequila(search: FlightSearch) -> List[FlightResult]:
+    response = requests.get('http://tequila-api/search', params=search.dict())
+    response.raise_for_status()
+    return [FlightResult(**flight) for flight in response.json()]
+
+def fetch_flight_details(flight_id: str) -> FlightResult:
+    response = requests.get(f'http://tequila-api/flights/{flight_id}')
+    response.raise_for_status()
+    return FlightResult(**response.json())

--- a/app/services.py
+++ b/app/services.py
@@ -1,0 +1,4 @@
+import requests
+
+def search_flights_in_tequila():
+    pass

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ requests
 pydantic
 pytest
 responses
+httpx

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,6 @@
+fastapi
+uvicorn
+requests
+pydantic
 pytest
+responses

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,2 @@
+def test_search_flights():
+    pass

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,2 +1,23 @@
+import responses
+from fastapi.testclient import TestClient
+from app.main import app
+
+client = TestClient(app)
+
+@responses.activate
 def test_search_flights():
-    pass
+    responses.add(responses.GET, 'http://tequila-api/search',
+                  json=[{'id': '1', 'origin': 'NYC', 'destination': 'LAX', 'departure_date': '2022-01-01', 'return_date': '2022-01-10', 'price': 200.0}], status=200)
+
+    response = client.get('/flights?origin=NYC&destination=LAX&departure_date=2022-01-01&return_date=2022-01-10')
+    assert response.status_code == 200
+    assert response.json() == [{'id': '1', 'origin': 'NYC', 'destination': 'LAX', 'departure_date': '2022-01-01', 'return_date': '2022-01-10', 'price': 200.0}]
+
+@responses.activate
+def test_get_flight():
+    responses.add(responses.GET, 'http://tequila-api/flights/1',
+                  json={'id': '1', 'origin': 'NYC', 'destination': 'LAX', 'departure_date': '2022-01-01', 'return_date': '2022-01-10', 'price': 200.0}, status=200)
+
+    response = client.get('/flights/1')
+    assert response.status_code == 200
+    assert response.json() == {'id': '1', 'origin': 'NYC', 'destination': 'LAX', 'departure_date': '2022-01-01', 'return_date': '2022-01-10', 'price': 200.0}

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1,0 +1,2 @@
+def test_search_flights_in_tequila():
+    pass

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1,2 +1,20 @@
+import responses
+from app.services import search_flights_in_tequila, fetch_flight_details
+from app.models import FlightSearch, FlightResult
+
+@responses.activate
 def test_search_flights_in_tequila():
-    pass
+    responses.add(responses.GET, 'http://tequila-api/search',
+                  json=[{'id': '1', 'origin': 'NYC', 'destination': 'LAX', 'departure_date': '2022-01-01', 'return_date': '2022-01-10', 'price': 200.0}], status=200)
+
+    search = FlightSearch(origin='NYC', destination='LAX', departure_date='2022-01-01', return_date='2022-01-10')
+    result = search_flights_in_tequila(search)
+    assert result == [FlightResult(id='1', origin='NYC', destination='LAX', departure_date='2022-01-01', return_date='2022-01-10', price=200.0)]
+
+@responses.activate
+def test_fetch_flight_details():
+    responses.add(responses.GET, 'http://tequila-api/flights/1',
+                  json={'id': '1', 'origin': 'NYC', 'destination': 'LAX', 'departure_date': '2022-01-01', 'return_date': '2022-01-10', 'price': 200.0}, status=200)
+
+    result = fetch_flight_details('1')
+    assert result == FlightResult(id='1', origin='NYC', destination='LAX', departure_date='2022-01-01', return_date='2022-01-10', price=200.0)


### PR DESCRIPTION
This PR defines the necessary endpoints for the flight search functionality and their routes. It includes two endpoints: one for searching flights and another for fetching flight details. It also includes request and response models for these endpoints, and tests for the endpoints and the new service function.

### Test Plan

pytest