### PR TITLE
PIME-11: Implement and Test Flight Search API Call

### DIFF
--- a/api/flight_search.py
+++ b/api/flight_search.py
@@ -1,0 +1,6 @@
+import requests
+
+
+def flight_search(params):
+    response = requests.get('https://tequila-api.kiwi.com/v2/search', params=params)
+    return response.json()

--- a/tests/test_flight_search.py
+++ b/tests/test_flight_search.py
@@ -1,0 +1,11 @@
+import unittest
+from unittest.mock import patch
+from api.flight_search import flight_search
+
+
+class TestFlightSearch(unittest.TestCase):
+    @patch('requests.get')
+    def test_flight_search(self, mock_get):
+        mock_get.return_value.json.return_value = {'flights': []}
+        result = flight_search({})
+        self.assertEqual(result, {'flights': []})


### PR DESCRIPTION
This PR implements the function to make the API call to the Tequila API for flight search. It also includes unit tests for this function.

### Test Plan

pytest