### PR TITLE
PIME-18: Fix error in API call

### DIFF
--- a/main.py
+++ b/main.py
@@ -11,7 +11,7 @@ def search(request: Request):
     return templates.TemplateResponse('search.html', {'request': request})
 
 @app.get('/search')
-def search_flights(from_city: str = Query(...), to_city: str = Query(...), date: str = Query(...)):
-    params = {'from': from_city, 'to': to_city, 'date': date}
+def search_flights(fly_from_city: str = Query(...), to_city: str = Query(...), date: str = Query(...)):
+    params = {'fly_from': fly_from_city, 'to': to_city, 'date': date}
     response = api.search_flights(params)
     return response

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -9,7 +9,7 @@ class TestMain(unittest.TestCase):
     @patch('main.api.search_flights', return_value={'flights': []})
     def test_search(self, mock_search_flights):
         client = TestClient(app)
-        response = client.get('/search?from_city=city1&to_city=city2&date=2022-12-31')
+        response = client.get('/search?fly_from_city=city1&to_city=city2&date=2022-12-31')
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {'flights': []})
-        mock_search_flights.assert_called_once_with({'from': 'city1', 'to': 'city2', 'date': '2022-12-31'})
+        mock_search_flights.assert_called_once_with({'fly_from': 'city1', 'to': 'city2', 'date': '2022-12-31'})


### PR DESCRIPTION
This PR fixes the error in the API call to the Tequila API. The departure location parameter was incorrectly named 'from'. It has been updated to 'fly_from' as expected by the Tequila API.

### Test Plan

pytest