### PR TITLE
PIME-20: Fix 'no locations to fly from' error

### DIFF
--- a/api.py
+++ b/api.py
@@ -4,7 +4,21 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
+CITY_TO_KIWI_ID = {
+'New York': 'NYC',
+'Los Angeles': 'LAX',
+'Chicago': 'CHI',
+'Houston': 'HOU',
+'Phoenix': 'PHX',
+'Philadelphia': 'PHL',
+'San Antonio': 'SAT',
+'San Diego': 'SAN',
+'Dallas': 'DFW',
+'San Jose': 'SJC'
+}
+
 def search_flights(params):
     headers = {'apikey': os.getenv('TEQUILA_API_KEY')}
+    params['fly_from'] = CITY_TO_KIWI_ID[params['fly_from']]
     response = requests.get('https://tequila-api.kiwi.com/v2/search', params=params, headers=headers)
     return response.json()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -8,5 +8,5 @@ class TestApi(unittest.TestCase):
     def test_search_flights(self, mock_get, mock_getenv):
         mock_get.return_value.json.return_value = {'flights': []}
         mock_getenv.return_value = 'test_api_key'
-        result = api.search_flights({})
+        result = api.search_flights({'fly_from': 'New York', 'to': 'Los Angeles', 'date': '2022-12-31'})
         self.assertEqual(result, {'flights': []})

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3,7 +3,6 @@ from unittest.mock import patch
 from fastapi.testclient import TestClient
 from main import app
 
-
 class TestMain(unittest.TestCase):
 
     @patch('main.api.search_flights', return_value={'flights': []})


### PR DESCRIPTION
This PR fixes the 'no locations to fly from' error by mapping city names to their corresponding Kiwi IDs before making the API call. A dictionary 'CITY_TO_KIWI_ID' has been added in 'api.py' for this purpose. The unit tests have also been updated to reflect these changes.

### Test Plan

pytest