### PR TITLE
PIME-23: Fix CSS issue

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,8 +1,11 @@
 from fastapi import FastAPI, Query, Request
 from fastapi.templating import Jinja2Templates
+from fastapi.staticfiles import StaticFiles
 import api
 
 app = FastAPI()
+
+app.mount('/static', StaticFiles(directory='static'), name='static')
 
 templates = Jinja2Templates(directory='templates')
 

--- a/templates/results.html
+++ b/templates/results.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-<link rel='stylesheet' type='text/css' href='/static/css/results.css'>
+<link rel='stylesheet' type='text/css' href='css/results.css'>
 <title>Flight Results</title>
 </head>
 <body>

--- a/templates/search.html
+++ b/templates/search.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <link rel='stylesheet' type='text/css' href='/static/css/search.css'>
+    <link rel='stylesheet' type='text/css' href='css/search.css'>
     <title>Flight Search</title>
 </head>
 <body>

--- a/tests/test_static.py
+++ b/tests/test_static.py
@@ -1,0 +1,14 @@
+import unittest
+from fastapi.testclient import TestClient
+from main import app
+
+class TestStatic(unittest.TestCase):
+
+    def test_css_files(self):
+        client = TestClient(app)
+        response = client.get('/static/css/search.css')
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('text/css', response.headers['content-type'])
+        response = client.get('/static/css/results.css')
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('text/css', response.headers['content-type'])


### PR DESCRIPTION
This PR fixes the issue of CSS files not being served correctly. It adds a new route to serve static files and updates the paths to the CSS files in the HTML templates. It also includes tests for the new static files route.

### Test Plan

pytest