### PR TITLE
PIME-24: Fix CSS file paths in HTML templates

### DIFF
--- a/templates/results.html
+++ b/templates/results.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-<link rel='stylesheet' type='text/css' href='css/results.css'>
+<link rel='stylesheet' type='text/css' href='/static/css/results.css'>
 <title>Flight Results</title>
 </head>
 <body>

--- a/templates/search.html
+++ b/templates/search.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <link rel='stylesheet' type='text/css' href='css/search.css'>
+    <link rel='stylesheet' type='text/css' href='/static/css/search.css'>
     <title>Flight Search</title>
 </head>
 <body>


### PR DESCRIPTION
This PR fixes the issue of 404 errors being returned for the CSS files. The paths of the CSS files in the HTML templates have been updated to include the `/static` prefix. This ensures that the application can find and load the CSS files correctly.

### Test Plan

pytest