### PR TITLE
PIME-25: Fix issue with no results shown

### DIFF
--- a/main.py
+++ b/main.py
@@ -17,4 +17,7 @@ def search(request: Request):
 def search_flights(request: Request, fly_from: str = Query(...), fly_to: str = Query(...), date_from: str = Query(...), date_to: str = Query(...)):
     params = {'fly_from': fly_from, 'fly_to': fly_to, 'date_from': date_from, 'date_to': date_to}
     response = api.search_flights(params)
-    return templates.TemplateResponse('results.html', {'request': request, 'flights': response['data']})
+    if response['data']:
+        return templates.TemplateResponse('results.html', {'request': request, 'flights': response['data']})
+    else:
+        return templates.TemplateResponse('no_results.html', {'request': request})

--- a/templates/no_results.html
+++ b/templates/no_results.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <link rel='stylesheet' type='text/css' href='/static/css/results.css'>
+    <title>No Results</title>
+</head>
+<body>
+    <h1>No results found for your search.</h1>
+</body>
+</html>

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -14,9 +14,10 @@ class TestMain(unittest.TestCase):
         mock_search_flights.assert_called_once_with({'fly_from': 'New York', 'fly_to': 'Los Angeles', 'date_from': '2022-12-31', 'date_to': '2022-12-31'})
 
     @patch('main.api.search_flights', return_value={'data': []})
-    def test_results(self, mock_search_flights):
+    def test_no_results(self, mock_search_flights):
         client = TestClient(app)
         response = client.get('/search?fly_from=New York&fly_to=Los Angeles&date_from=2022-12-31&date_to=2022-12-31')
         self.assertEqual(response.status_code, 200)
         self.assertIn('text/html', response.headers['content-type'])
+        self.assertIn('No results found for your search.', response.text)
         mock_search_flights.assert_called_once_with({'fly_from': 'New York', 'fly_to': 'Los Angeles', 'date_from': '2022-12-31', 'date_to': '2022-12-31'})


### PR DESCRIPTION
This PR addresses the issue where no results were shown when a user searched for flights. The problem was due to an error in the data processing in the `search_flights` function in `main.py`. This has been fixed by adding a check to ensure that the `response['data']` is not empty before it is passed to the template. Unit tests have been added to prevent future regressions.

### Test Plan

pytest