### PR TITLE
PIME-25: Render flight results in results.html

### DIFF
--- a/templates/results.html
+++ b/templates/results.html
@@ -6,7 +6,26 @@
 </head>
 <body>
 <table>
-<!-- Table headers and data will be dynamically generated -->
+<tr>
+<th>Departure City</th>
+<th>Arrival City</th>
+<th>Departure Date</th>
+<th>Arrival Date</th>
+<th>Duration</th>
+<th>Price</th>
+<th>Airline</th>
+</tr>
+{% for flight in flights %}
+<tr>
+<td>{{ flight.cityFrom }}</td>
+<td>{{ flight.cityTo }}</td>
+<td>{{ flight.local_departure }}</td>
+<td>{{ flight.local_arrival }}</td>
+<td>{{ flight.duration.total }}</td>
+<td>{{ flight.price }}</td>
+<td>{{ flight.airlines[0] }}</td>
+</tr>
+{% endfor %}
 </table>
 </body>
 </html>

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3,6 +3,18 @@ from unittest.mock import patch
 from fastapi.testclient import TestClient
 from main import app
 
+mock_flight_data = [
+    {
+        'cityFrom': 'New York',
+        'cityTo': 'Los Angeles',
+        'local_departure': '2022-12-31T00:00:00',
+        'local_arrival': '2022-12-31T12:00:00',
+        'duration': {'total': 7200},
+        'price': 500,
+        'airlines': ['AA']
+    }
+]
+
 class TestMain(unittest.TestCase):
 
     @patch('main.api.search_flights', return_value={'data': []})
@@ -13,10 +25,18 @@ class TestMain(unittest.TestCase):
         self.assertIn('text/html', response.headers['content-type'])
         mock_search_flights.assert_called_once_with({'fly_from': 'New York', 'fly_to': 'Los Angeles', 'date_from': '2022-12-31', 'date_to': '2022-12-31'})
 
-    @patch('main.api.search_flights', return_value={'data': []})
-    def test_results(self, mock_search_flights):
+    @patch('main.api.search_flights', return_value={'data': mock_flight_data})
+    def test_search_flights_results(self, mock_search_flights):
         client = TestClient(app)
         response = client.get('/search?fly_from=New York&fly_to=Los Angeles&date_from=2022-12-31&date_to=2022-12-31')
         self.assertEqual(response.status_code, 200)
         self.assertIn('text/html', response.headers['content-type'])
+        for flight in mock_flight_data:
+            self.assertIn(flight['cityFrom'], response.text)
+            self.assertIn(flight['cityTo'], response.text)
+            self.assertIn(flight['local_departure'], response.text)
+            self.assertIn(flight['local_arrival'], response.text)
+            self.assertIn(str(flight['duration']['total']), response.text)
+            self.assertIn(str(flight['price']), response.text)
+            self.assertIn(flight['airlines'][0], response.text)
         mock_search_flights.assert_called_once_with({'fly_from': 'New York', 'fly_to': 'Los Angeles', 'date_from': '2022-12-31', 'date_to': '2022-12-31'})


### PR DESCRIPTION
This PR addresses ticket PIME-25. It updates the results.html file to include a dynamic table that is populated with flight data received from the API. The table includes columns for departure city, arrival city, departure date, arrival date, duration, price, and airline. The PR also includes a unit test for the updated functionality.

### Test Plan

pytest